### PR TITLE
fix: search all Steam libraries for compatdata prefix

### DIFF
--- a/src/gamelib_helper/steam_game.rs
+++ b/src/gamelib_helper/steam_game.rs
@@ -54,9 +54,20 @@ pub fn get_game(app_id: u32, steam_dir: steamlocate::SteamDir) -> Result<SteamGa
         .with_context(|| format!("Couldn't find app with ID {}", app_id))?;
     let path = library.resolve_app_dir(&app);
     let name = app.name.context("No app name?")?.to_string();
-    let prefix = library
-        .path()
-        .join(format!("steamapps/compatdata/{app_id}/pfx"));
+
+    // Search all libraries for compatdata (Steam may place it on a different
+    // drive than the game itself, e.g. internal drive vs SD card)
+    let prefix = steam_dir
+        .libraries()?
+        .flatten()
+        .map(|lib| lib.path().join(format!("steamapps/compatdata/{app_id}/pfx")))
+        .find(|p| p.exists())
+        .unwrap_or_else(|| {
+            // Fall back to the game's library if compatdata hasn't been created yet
+            library
+                .path()
+                .join(format!("steamapps/compatdata/{app_id}/pfx"))
+        });
 
     let steam_game = SteamGame {
         app_id,


### PR DESCRIPTION
## Problem

When a game is installed on an SD card (e.g. Steam Deck), MateriaForge assumes the `compatdata/pfx` directory is in the same Steam library as the game. However, Steam often creates the compatdata on the **internal drive** regardless of where the game is installed, causing Proton to fail with `FileNotFoundError` on `pfx.lock`.

## Fix

Search all Steam libraries for an existing `compatdata/{app_id}/pfx` directory instead of only checking the game's library. Falls back to the game's library path if no existing compatdata is found.

## Testing

Tested on Steam Deck with FF7 (app ID 3837340) installed on SD card, with compatdata on internal drive. Before this fix, MateriaForge failed to launch the installer. After, it correctly finds the prefix at `~/.steam/root/steamapps/compatdata/3837340/pfx`.