### PR TITLE
fix: Do not warn for duplicate detection in cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 wildcards = "deny"
 deny = [
   { name = "openssl" },


### PR DESCRIPTION
Reason for it is that you don't have full control and that happens because some dependencies inherit one package version and another one an older/newer version than the former. This "chaotic" resolution is left to Cargo and you have basically two options:
- Ignore it ( our way here ) or,
- Pin specific dependencies and hope the best that version works across all dependencies

I think it's reasonable to ignore it for now and let Cargo do its own work somehow.

After this PR, the output of `cargo deny` will be the following:
```sh
$ cargo deny check advisories bans sources
advisories ok, bans ok, sources ok
```