### PR TITLE
feat: Allow users to install 7th/J8 only if relative game detected

### DIFF
--- a/src/installers/common.rs
+++ b/src/installers/common.rs
@@ -14,7 +14,7 @@ use crate::{
     resource_handler,
 };
 
-use super::target::{InstallTarget, FF7_GOG_APPID};
+use super::{ff7::FF7_GOG_APPID, target::InstallTarget};
 
 pub fn download_asset(repo: &str, destination: PathBuf, prerelease: bool) -> Result<PathBuf> {
     let client = reqwest::blocking::Client::new();

--- a/src/installers/ff7.rs
+++ b/src/installers/ff7.rs
@@ -9,9 +9,14 @@ use crate::{
 
 use super::{
     common,
+    detected_app_id,
     game_installer::{Detection, GameInstaller},
-    target::{InstallTarget, FF7_2026_APPID, FF7_APPID, FF7_GOG_APPID},
+    target::InstallTarget,
 };
+
+pub(super) const FF7_APPID: u32 = 39140;
+pub(super) const FF7_2026_APPID: u32 = 3837340;
+pub(super) const FF7_GOG_APPID: u32 = 1698970154;
 
 pub struct FF7Target;
 pub static TARGET: FF7Target = FF7Target;
@@ -71,6 +76,14 @@ pub struct FF7Installer;
 
 pub const INSTALLER: FF7Installer = FF7Installer;
 
+fn is_ff7_steam_app_id(app_id: u32) -> bool {
+    matches!(app_id, FF7_APPID | FF7_2026_APPID)
+}
+
+fn is_ff7_gog_app_id(app_id: u32) -> bool {
+    app_id == FF7_GOG_APPID
+}
+
 impl GameInstaller for FF7Installer {
     fn target(&self) -> &'static dyn InstallTarget {
         &TARGET
@@ -82,12 +95,12 @@ impl GameInstaller for FF7Installer {
 
     fn detect(&self, installs: &[DetectedGame]) -> Detection {
         let steam_index = installs.iter().position(|game| {
-            game.title.to_lowercase().contains("final fantasy vii")
-                && game.source == SupportedLaunchers::Steam
+            game.source == SupportedLaunchers::Steam
+                && detected_app_id(game).is_some_and(is_ff7_steam_app_id)
         });
         let alt_index = installs.iter().position(|game| {
-            game.title.to_lowercase().contains("final fantasy vii")
-                && game.source == SupportedLaunchers::HeroicGamesGOG
+            game.source == SupportedLaunchers::HeroicGamesGOG
+                && detected_app_id(game).is_some_and(is_ff7_gog_app_id)
         });
 
         Detection {
@@ -137,6 +150,7 @@ impl GameInstaller for FF7Installer {
     fn resolve_steam_game(
         &self,
         steam_dir: steamlocate::SteamDir,
+        preferred_app_id: Option<u32>,
     ) -> Result<gamelib_helper::steam_game::SteamGame> {
         let original = gamelib_helper::steam_game::get_game(FF7_APPID, steam_dir.clone()).ok();
         let remaster =
@@ -149,11 +163,15 @@ impl GameInstaller for FF7Installer {
         match (original, remaster) {
             (Some(og), Some(rm)) => {
                 let choices = &[&og.name, &format!("{} (2026)", rm.name)];
+                let default_selection = match preferred_app_id {
+                    Some(FF7_2026_APPID) => 1,
+                    _ => 0,
+                };
                 let selection = dialoguer::Select::with_theme(&ColorfulTheme::default())
                     .with_prompt(
                         "Multiple Steam installations of FF7 were detected. Which one do you want to patch?",
                     )
-                    .default(0)
+                    .default(default_selection)
                     .items(choices)
                     .interact()
                     .context("Selection failed")?;

--- a/src/installers/ff8.rs
+++ b/src/installers/ff8.rs
@@ -8,9 +8,12 @@ use crate::{
 
 use super::{
     common,
+    detected_app_id,
     game_installer::{Detection, GameInstaller},
-    target::{InstallTarget, FF8_APPID},
+    target::InstallTarget,
 };
+
+pub(super) const FF8_APPID: u32 = 39150;
 
 pub struct FF8Target;
 pub static TARGET: FF8Target = FF8Target;
@@ -61,6 +64,10 @@ pub struct FF8Installer;
 
 pub const INSTALLER: FF8Installer = FF8Installer;
 
+fn is_ff8_steam_app_id(app_id: u32) -> bool {
+    app_id == FF8_APPID
+}
+
 impl GameInstaller for FF8Installer {
     fn target(&self) -> &'static dyn InstallTarget {
         &TARGET
@@ -72,9 +79,8 @@ impl GameInstaller for FF8Installer {
 
     fn detect(&self, installs: &[DetectedGame]) -> Detection {
         let steam_index = installs.iter().position(|game| {
-            let title = game.title.to_lowercase();
-            (title.contains("final fantasy viii") || title.contains("final fantasy 8"))
-                && game.source == SupportedLaunchers::Steam
+            game.source == SupportedLaunchers::Steam
+                && detected_app_id(game).is_some_and(is_ff8_steam_app_id)
         });
 
         Detection {
@@ -98,6 +104,7 @@ impl GameInstaller for FF8Installer {
     fn resolve_steam_game(
         &self,
         steam_dir: steamlocate::SteamDir,
+        _preferred_app_id: Option<u32>,
     ) -> Result<gamelib_helper::steam_game::SteamGame> {
         gamelib_helper::steam_game::get_game(FF8_APPID, steam_dir)
             .context("Couldn't find Steam installation of FF8")

--- a/src/installers/game_installer.rs
+++ b/src/installers/game_installer.rs
@@ -28,7 +28,11 @@ pub trait GameInstaller {
     ) -> Result<Option<usize>>;
 
     fn steam_search_label(&self) -> &'static str;
-    fn resolve_steam_game(&self, steam_dir: steamlocate::SteamDir) -> Result<SteamGame>;
+    fn resolve_steam_game(
+        &self,
+        steam_dir: steamlocate::SteamDir,
+        preferred_app_id: Option<u32>,
+    ) -> Result<SteamGame>;
 
     fn resolve_nonsteam_game(
         &self,

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -15,6 +15,19 @@ mod target;
 
 use game_installer::{Detection, GameInstaller};
 
+pub(super) fn detected_app_id(game: &lib_game_detector::data::Game) -> Option<u32> {
+    game.launch_command
+        .get_args()
+        .filter_map(|arg| arg.to_str())
+        .find_map(|arg| {
+            arg.strip_prefix("steam://rungameid/")
+                .or_else(|| arg.split("steam://rungameid/").nth(1))
+                .or_else(|| arg.strip_prefix("heroic://launch/gog/")
+                    .or_else(|| arg.split("heroic://launch/gog/").nth(1)))
+                .and_then(|value| value.chars().take_while(|c| c.is_ascii_digit()).collect::<String>().parse::<u32>().ok())
+        })
+}
+
 pub fn run(is_deck: bool) -> Result<()> {
     let detector = get_detector();
     let installs = detector.get_all_detected_games();
@@ -93,7 +106,7 @@ fn run_install(
 
         let find_message = format!("Finding {}...", installer.steam_search_label());
         let mut steam_game = common::with_spinner(&find_message, "Done!", || {
-            installer.resolve_steam_game(steam_dir.clone())
+            installer.resolve_steam_game(steam_dir.clone(), detected_app_id(found_game))
         })?;
 
         steam_game.runner = Some(gamelib_helper::steam_game::select_runner(&steam_game)?);

--- a/src/installers/target.rs
+++ b/src/installers/target.rs
@@ -1,8 +1,3 @@
-pub const FF7_APPID: u32 = 39140;
-pub const FF7_2026_APPID: u32 = 3837340;
-pub const FF7_GOG_APPID: u32 = 1698970154;
-pub const FF8_APPID: u32 = 39150;
-
 pub trait InstallTarget {
     fn target_key(&self) -> &'static str;
     fn mod_loader_name(&self) -> &'static str;


### PR DESCRIPTION
This PR fixes an issue that was made more visible since #23

Because the current game support comparison was based on the name, `7th Heaven` was shown an option because `Final Fantasy VII` was matching `Final Fantasy VIII` because it is contained within this one ( yes, just because of one less capital `i` ).

I patched the code to use the Steam App IDs instead to detect them, making the process more strict but also more bullet proof. The App IDs also since they were constants in the code base, has been now moved to the respective `ff7.rs` and `ff8.rs` for better maintainability purpose.

---

From the user perspective, this is how MateriaForge will look like now.

**When launched and both games are detected as installed:**
<img width="1410" height="876" alt="Screenshot_20260623_000329" src="https://github.com/user-attachments/assets/d3f9648c-5ac6-4047-b639-2645828822f7" />

**Installing 7th Heaven, when multiple games have been detected:**
<img width="1410" height="876" alt="Screenshot_20260623_000521" src="https://github.com/user-attachments/assets/d14c1ea3-d508-46d6-b5e5-c794bb9d3770" />

**Installing Junction VIII, when multiple games have been detected:**
<img width="1410" height="876" alt="Screenshot_20260623_000617" src="https://github.com/user-attachments/assets/1b0c13f5-b754-4797-9e31-fdaafcf3d16f" />

**Installing 7th Heaven, when only FF7 is detected:**
<img width="1410" height="876" alt="Screenshot_20260623_001829" src="https://github.com/user-attachments/assets/93f215ef-adc2-4d4a-8944-dc284602b209" />

**Installing Junction VIII, when only FF8 is detected:**
<img width="1410" height="876" alt="Screenshot_20260623_000744" src="https://github.com/user-attachments/assets/f576aae7-8bf5-42d5-bac5-205ab2158415" />

**Installing 7th Heaven, when multiple FF7 copies are detected:**
<img width="1410" height="876" alt="Screenshot_20260623_003604" src="https://github.com/user-attachments/assets/671f5e2d-8a7a-44f0-aee3-ab0ed14bcc05" />
<img width="1410" height="876" alt="Screenshot_20260623_003641" src="https://github.com/user-attachments/assets/6adffd12-37c6-4cca-9539-e2b89d907fd4" />