### PR TITLE
Add support for FF8R Steam/GOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MateriaForge is the successor to [7thDeck](https://github.com/dotaxis/7thDeck) a
 ## Features
 
 - **7th Heaven installation**: downloads, configures, and launches 7th Heaven with no manual setup
-- **Junction VIII installation**: downloads, configures, and launches Junction VIII with no manual setup
+- **Junction VIII installation**: downloads, configures, and launches Junction VIII for Final Fantasy VIII and Final Fantasy VIII Remastered with no manual setup
 - **Multi-platform game detection**: supports multiple storefronts out of the box
 - **Written in Rust**: fast, reliable, and expandable
 
@@ -21,7 +21,8 @@ MateriaForge is the successor to [7thDeck](https://github.com/dotaxis/7thDeck) a
 |------------|------|-------|--------------|--------------|-------------------------|
 | **7th Heaven** | Final Fantasy VII (2026) | ✅ | ✅ | 🔜 | #ff7-linux |
 | |Final Fantasy VII (2013) | ✅ | N/A | N/A | #ff7-linux |
-| **Junction VIII** | Final Fantasy VIII (2013) | ✅ | N/A | N/A | #ff8-linux |
+| **Junction VIII** | Final Fantasy VIII Remastered | ✅ | ✅ | N/A | #ff8-linux |
+| | Final Fantasy VIII (2013) | ✅ | N/A | N/A | #ff8-linux |
 ---
 
 ## Installation

--- a/resources/junction_viii_settings.xml
+++ b/resources/junction_viii_settings.xml
@@ -21,7 +21,7 @@
   </Subscriptions>
   <LibraryLocation>LIBRARY_LOCATION</LibraryLocation>
   <FF8Exe>FF8_EXE</FF8Exe>
-  <FF8InstalledVersion>Steam</FF8InstalledVersion>
+  <FF8InstalledVersion>FF8_VERSION</FF8InstalledVersion>
   <FFNxUpdateChannel>UPDATE_CHANNEL</FFNxUpdateChannel>
   <AppUpdateChannel>UPDATE_CHANNEL</AppUpdateChannel>
   <Options>

--- a/src/gamelib_helper/steam_lib.rs
+++ b/src/gamelib_helper/steam_lib.rs
@@ -132,6 +132,8 @@ pub fn set_controller_config(
         3837340 => ("(2026)", false),
         1698970154 => ("(gog)", true),
         39150 => ("", false),
+        1026680 => ("", false),
+        1086370078 => ("", true),
         _ => ("(unknown)", false),
     };
     let template = "controller_neptune_gamepad+mouse+click.vdf";
@@ -151,7 +153,7 @@ pub fn set_controller_config(
         ));
     }
     if steam_shortcut {
-        let shortcut_name = if app_id == 39150 {
+        let shortcut_name = if matches!(app_id, 39150 | 1026680 | 1086370078) {
             "launch junction viii".to_string()
         } else {
             format!("launch 7th heaven {shortcut_id}")

--- a/src/gamelib_helper/steam_lib.rs
+++ b/src/gamelib_helper/steam_lib.rs
@@ -133,7 +133,7 @@ pub fn set_controller_config(
         1698970154 => ("(gog)", true),
         39150 => ("", false),
         1026680 => ("", false),
-        1086370078 => ("", true),
+        1086370078 => ("(gog)", true),
         _ => ("(unknown)", false),
     };
     let template = "controller_neptune_gamepad+mouse+click.vdf";

--- a/src/installers/ff8.rs
+++ b/src/installers/ff8.rs
@@ -171,7 +171,7 @@ impl GameInstaller for FF8Installer {
 
         match (original, remaster) {
             (Some(og), Some(rm)) => {
-                let choices = &[&og.name, &format!("{} (Remastered)", rm.name)];
+                let choices = &[&og.name, &rm.name];
                 let default_selection = match preferred_app_id {
                     Some(FF8_REMASTERED_APPID) => 1,
                     _ => 0,

--- a/src/installers/ff8.rs
+++ b/src/installers/ff8.rs
@@ -1,8 +1,9 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use dialoguer::theme::ColorfulTheme;
 use lib_game_detector::data::{Game as DetectedGame, SupportedLaunchers};
 
 use crate::{
-    gamelib_helper::{self, PrefixedGame},
+    gamelib_helper::{self, gog_game, PrefixedGame},
     resource_handler,
 };
 
@@ -13,6 +14,8 @@ use super::{
 };
 
 pub(super) const FF8_APPID: u32 = 39150;
+pub(super) const FF8_REMASTERED_APPID: u32 = 1026680;
+pub(super) const FF8_GOG_APPID: u32 = 1086370078;
 
 pub struct FF8Target;
 pub static TARGET: FF8Target = FF8Target;
@@ -64,7 +67,35 @@ pub struct FF8Installer;
 pub const INSTALLER: FF8Installer = FF8Installer;
 
 fn is_ff8_steam_app_id(app_id: u32) -> bool {
-    app_id == FF8_APPID
+    matches!(app_id, FF8_APPID | FF8_REMASTERED_APPID)
+}
+
+fn is_ff8_gog_app_id(app_id: u32) -> bool {
+    app_id == FF8_GOG_APPID
+}
+
+fn ensure_ff8_user_slot(game: &dyn PrefixedGame) -> Result<()> {
+    match game.app_id() {
+        FF8_APPID => {
+            let ff8_user_base = common::wine_user_documents_dir(game.prefix())
+                .join("Square Enix/FINAL FANTASY VIII Steam");
+            common::ensure_wine_user_slot(&ff8_user_base, "user_12345678")?;
+        }
+        FF8_REMASTERED_APPID | FF8_GOG_APPID => {
+            let edition = match game.app_id() {
+                FF8_GOG_APPID => "GOG",
+                _ => "Steam",
+            };
+            let ff8_user_base = common::wine_user_documents_dir(game.prefix())
+                .join("My Games")
+                .join("FINAL FANTASY VIII Remastered")
+                .join(edition);
+            common::ensure_wine_user_slot(&ff8_user_base, "0/game_data/user/saves")?;
+        }
+        _ => {}
+    }
+
+    Ok(())
 }
 
 impl GameInstaller for FF8Installer {
@@ -81,10 +112,14 @@ impl GameInstaller for FF8Installer {
             game.source == SupportedLaunchers::Steam
                 && detected_app_id(game).is_some_and(is_ff8_steam_app_id)
         });
+        let alt_index = installs.iter().position(|game| {
+            game.source == SupportedLaunchers::HeroicGamesGOG
+                && detected_app_id(game).is_some_and(is_ff8_gog_app_id)
+        });
 
         Detection {
             steam_index,
-            alt_index: None,
+            alt_index,
         }
     }
 
@@ -93,16 +128,84 @@ impl GameInstaller for FF8Installer {
         _installs: &[DetectedGame],
         detection: Detection,
     ) -> Result<Option<usize>> {
-        Ok(detection.steam_index)
+        let selected = match (detection.steam_index, detection.alt_index) {
+            (Some(steam), Some(gog)) => {
+                let choices = &["Steam", "Heroic Games"];
+                let selection = dialoguer::Select::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Multiple versions of FF8 detected. Which one do you want to use?")
+                    .default(0)
+                    .items(choices)
+                    .interact()?;
+
+                match selection {
+                    0 => steam,
+                    1 => gog,
+                    _ => unreachable!(),
+                }
+            }
+            (None, Some(gog)) => {
+                log::info!("Heroic Games Launcher install detected!");
+                gog
+            }
+            (Some(steam), None) => {
+                log::info!("Steam install detected!");
+                steam
+            }
+            (None, None) => return Ok(None),
+        };
+
+        Ok(Some(selected))
     }
 
     fn resolve_steam_game(
         &self,
         steam_dir: steamlocate::SteamDir,
-        _preferred_app_id: Option<u32>,
+        preferred_app_id: Option<u32>,
     ) -> Result<gamelib_helper::steam_game::SteamGame> {
-        gamelib_helper::steam_game::get_game(FF8_APPID, steam_dir)
-            .context("Couldn't find Steam installation of FF8")
+        let original = gamelib_helper::steam_game::get_game(FF8_APPID, steam_dir.clone()).ok();
+        let remaster = gamelib_helper::steam_game::get_game(FF8_REMASTERED_APPID, steam_dir).ok();
+
+        if original.is_none() && remaster.is_none() {
+            bail!("Couldn't find any supported Steam version of FF8");
+        }
+
+        match (original, remaster) {
+            (Some(og), Some(rm)) => {
+                let choices = &[&og.name, &format!("{} (Remastered)", rm.name)];
+                let default_selection = match preferred_app_id {
+                    Some(FF8_REMASTERED_APPID) => 1,
+                    _ => 0,
+                };
+                let selection = dialoguer::Select::with_theme(&ColorfulTheme::default())
+                    .with_prompt(
+                        "Multiple Steam installations of FF8 were detected. Which one do you want to patch?",
+                    )
+                    .default(default_selection)
+                    .items(choices)
+                    .interact()
+                    .context("Selection failed")?;
+
+                match selection {
+                    0 => Ok(og),
+                    1 => Ok(rm),
+                    _ => unreachable!(),
+                }
+            }
+            (Some(og), None) => Ok(og),
+            (None, Some(rm)) => Ok(rm),
+            (None, None) => unreachable!(),
+        }
+    }
+
+    fn resolve_nonsteam_game(
+        &self,
+        found_game: &DetectedGame,
+    ) -> Result<(Box<dyn PrefixedGame>, &'static str)> {
+        let game = Box::new(
+            gog_game::get_game(FF8_GOG_APPID, found_game)
+                .context("Failed to get GOG game details")?,
+        );
+        Ok((game, "gog"))
     }
 
     fn patch_install(
@@ -111,20 +214,40 @@ impl GameInstaller for FF8Installer {
         game: &dyn PrefixedGame,
         update_channel: &str,
     ) -> Result<()> {
-        let ff8_user_base = common::wine_user_documents_dir(game.prefix())
-            .join("Square Enix/FINAL FANTASY VIII Steam");
-        common::ensure_wine_user_slot(&ff8_user_base, "user_12345678")?;
+        ensure_ff8_user_slot(game)?;
 
         let mut settings_xml = resource_handler::as_str(
             "settings.xml".to_string(),
             install_path.join("J8Workshop"),
             resource_handler::JUNCTION_VIII_SETTINGS_XML,
         );
-        let full = game.path().join("FF8_en.exe").to_string_lossy().to_string();
-        let trimmed = full
-            .find("/steamapps/")
-            .map_or(full.as_str(), |i| &full[i..]);
-        let ff8_exe = format!("S:{}", trimmed.replace('/', "\\"));
+        let ff8_version = match game.app_id() {
+            FF8_APPID => "Steam",
+            FF8_REMASTERED_APPID => "Remastered",
+            FF8_GOG_APPID => "GOG",
+            _ => "Unknown",
+        };
+        let ff8_exe_name = match game.app_id() {
+            FF8_APPID => "FF8_en.exe",
+            FF8_REMASTERED_APPID | FF8_GOG_APPID => "ff8.exe",
+            _ => "ff8.exe",
+        };
+        let ff8_exe = match game.app_id() {
+            FF8_GOG_APPID => format!(
+                "Z:{}",
+                game.path()
+                    .join(ff8_exe_name)
+                    .to_string_lossy()
+                    .replace('/', "\\")
+            ),
+            _ => {
+                let full = game.path().join(ff8_exe_name).to_string_lossy().to_string();
+                let trimmed = full
+                    .find("/steamapps/")
+                    .map_or(full.as_str(), |i| &full[i..]);
+                format!("S:{}", trimmed.replace('/', "\\"))
+            }
+        };
 
         let library_location = format!(
             "Z:{}",
@@ -138,6 +261,7 @@ impl GameInstaller for FF8Installer {
             .contents
             .replace("LIBRARY_LOCATION", &library_location)
             .replace("FF8_EXE", &ff8_exe)
+            .replace("FF8_VERSION", ff8_version)
             .replace("UPDATE_CHANNEL", update_channel);
         settings_xml.write()?;
 

--- a/src/launcher/main.rs
+++ b/src/launcher/main.rs
@@ -7,8 +7,10 @@ use std::{env, path::Path};
 use materia_forge::gamelib_helper::{Game, PrefixRunner};
 use materia_forge::{config_handler, gamelib_helper, logging};
 
-static FF7_GOG_APPID: u32 = 1698970154;
-static FF8_APPID: u32 = 39150;
+const FF7_GOG_APPID: u32 = 1698970154;
+const FF8_APPID: u32 = 39150;
+const FF8_REMASTERED_APPID: u32 = 1026680;
+const FF8_GOG_APPID: u32 = 1086370078;
 
 fn run_exe<G: Game + PrefixRunner>(game: &G, exe: std::path::PathBuf) -> Result<()> {
     if let Some(runner) = game.runner() {
@@ -54,7 +56,10 @@ fn main() -> Result<()> {
         .and_then(|value| value.parse::<u32>().ok());
     let install_target = config_handler::read_value("target")
         .unwrap_or_else(|_| {
-            if app_id == Some(FF8_APPID) {
+            if matches!(
+                app_id,
+                Some(FF8_APPID | FF8_REMASTERED_APPID | FF8_GOG_APPID)
+            ) {
                 "ff8".to_string()
             } else {
                 "ff7".to_string()
@@ -83,12 +88,17 @@ fn main() -> Result<()> {
         "gog" => {
             let g = lib_game_detector::get_detector()
                 .get_all_detected_games_from_specific_launcher(SupportedLaunchers::HeroicGamesGOG);
+            let (gog_app_id, title_match) = if install_target == "ff8" {
+                (FF8_GOG_APPID, "final fantasy viii")
+            } else {
+                (FF7_GOG_APPID, "final fantasy vii")
+            };
             let heroic_game = g
                 .iter()
                 .flatten()
-                .find(|game| game.title.to_lowercase().contains("final fantasy vii"))
-                .unwrap();
-            let game = gamelib_helper::gog_game::get_game(FF7_GOG_APPID, &heroic_game)
+                .find(|game| game.title.to_lowercase().contains(title_match))
+                .with_context(|| format!("Configured type=gog, but {title_match} was not found"))?;
+            let game = gamelib_helper::gog_game::get_game(gog_app_id, &heroic_game)
                 .context("Configured type=gog, but GOG game was not found")?;
             run_exe(&game, loader_exe)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn draw_header() {
     let title = format!("Welcome to MateriaForge {VERSION}");
     let mut description = vec![
         "This script will:",
-        "1. Detect supported FF7 and FF8 Steam installs (plus FF7 GOG via Heroic)",
+        "1. Detect supported FF7/FF8 Steam/GOG installs (GOG support via Heroic)",
         "2. Apply proton prefix patches for the selected game",
         "3. Install the corresponding mod loader to a folder of your choosing",
         "4. Optionally add a desktop shortcut and Steam shortcut for easy access",

--- a/src/tests/ff8.rs
+++ b/src/tests/ff8.rs
@@ -4,12 +4,63 @@
 //! reach its private items through `use super::*`.
 
 use super::*;
+use crate::gamelib_helper::{Game, PrefixRunner, Runner};
 use crate::installers::tests::detected;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+struct FakeGame {
+    app_id: u32,
+    path: PathBuf,
+    prefix: PathBuf,
+}
+
+impl Game for FakeGame {
+    fn app_id(&self) -> u32 {
+        self.app_id
+    }
+
+    fn name(&self) -> &str {
+        "Fake FF8"
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn prefix(&self) -> &Path {
+        &self.prefix
+    }
+
+    fn runner(&self) -> Option<&Runner> {
+        None
+    }
+}
+
+impl PrefixRunner for FakeGame {
+    fn run_in_prefix(&self, _exe_to_launch: PathBuf, _args: Option<Vec<String>>) -> Result<()> {
+        Ok(())
+    }
+}
 
 fn steam_ff8() -> DetectedGame {
     detected(
         SupportedLaunchers::Steam,
         &format!("steam://rungameid/{FF8_APPID}"),
+    )
+}
+
+fn steam_ff8_remastered() -> DetectedGame {
+    detected(
+        SupportedLaunchers::Steam,
+        &format!("steam://rungameid/{FF8_REMASTERED_APPID}"),
+    )
+}
+
+fn gog_ff8() -> DetectedGame {
+    detected(
+        SupportedLaunchers::HeroicGamesGOG,
+        &format!("heroic://launch/gog/{FF8_GOG_APPID}"),
     )
 }
 
@@ -24,6 +75,29 @@ fn detects_a_steam_install() {
     let detection = INSTALLER.detect(&installs);
 
     assert_eq!(detection.steam_index, Some(1));
+    assert_eq!(detection.alt_index, None);
+    assert!(detection.is_detected());
+}
+
+#[test]
+fn detects_a_remastered_steam_install() {
+    let installs = [unrelated_steam_game(), steam_ff8_remastered()];
+
+    let detection = INSTALLER.detect(&installs);
+
+    assert_eq!(detection.steam_index, Some(1));
+    assert_eq!(detection.alt_index, None);
+    assert!(detection.is_detected());
+}
+
+#[test]
+fn detects_a_gog_install() {
+    let installs = [unrelated_steam_game(), gog_ff8()];
+
+    let detection = INSTALLER.detect(&installs);
+
+    assert_eq!(detection.steam_index, None);
+    assert_eq!(detection.alt_index, Some(1));
     assert!(detection.is_detected());
 }
 
@@ -34,5 +108,42 @@ fn detects_nothing_without_ff8() {
     let detection = INSTALLER.detect(&installs);
 
     assert_eq!(detection.steam_index, None);
+    assert_eq!(detection.alt_index, None);
     assert!(!detection.is_detected());
+}
+
+#[test]
+fn creates_remastered_steam_save_slot() {
+    let tmp = TempDir::new().unwrap();
+    let game = FakeGame {
+        app_id: FF8_REMASTERED_APPID,
+        path: tmp.path().join("game"),
+        prefix: tmp.path().join("prefix"),
+    };
+
+    ensure_ff8_user_slot(&game).unwrap();
+
+    assert!(
+        game.prefix
+            .join("drive_c/users/steamuser/Documents/My Games/FINAL FANTASY VIII Remastered/Steam/0/game_data/user/saves")
+            .is_dir()
+    );
+}
+
+#[test]
+fn creates_remastered_gog_save_slot() {
+    let tmp = TempDir::new().unwrap();
+    let game = FakeGame {
+        app_id: FF8_GOG_APPID,
+        path: tmp.path().join("game"),
+        prefix: tmp.path().join("prefix"),
+    };
+
+    ensure_ff8_user_slot(&game).unwrap();
+
+    assert!(
+        game.prefix
+            .join("drive_c/users/steamuser/Documents/My Games/FINAL FANTASY VIII Remastered/GOG/0/game_data/user/saves")
+            .is_dir()
+    );
 }


### PR DESCRIPTION
This PR will add support for FF8 Remastered, currently supported only when running MateriaForge with `--canary` ( as you need both Junction VIII and FFNx in canary mode ).

But this change will work as well without the flag, as soon as we will release it Stable. From MF point of view though, no further changes will be required.

Please let me know if there's anything we can optimize, but here's some proof of the game running on the Deck:
<img width="1280" height="800" alt="immagine" src="https://github.com/user-attachments/assets/37bb9204-1124-40ed-a156-b34f33fbe416" />
<img width="1280" height="800" alt="immagine" src="https://github.com/user-attachments/assets/840ebb22-9192-43c8-94c1-151e7aae5b4e" />

Any feedback is welcome. Hope you appreciate this one.